### PR TITLE
refactor(cli): remove unused directoryExists helper

### DIFF
--- a/packages/gitbackup-cli/src/main.ts
+++ b/packages/gitbackup-cli/src/main.ts
@@ -84,25 +84,6 @@ async function fetchUserRepositories(octokit: Octokit): Promise<Repository[]> {
 }
 
 /**
- * Checks if a directory exists.
- */
-async function directoryExists(dirPath: string): Promise<boolean> {
-    try {
-        // **CRITICAL FIX:** Ensure path is absolute before checking
-        const absolutePath = path.resolve(dirPath);
-        const stats = await fs.stat(absolutePath);
-        return stats.isDirectory();
-    } catch (error: any) {
-        if (error.code === 'ENOENT') {
-            return false; // Doesn't exist
-        }
-        // Log other stat errors
-        console.error(`Error checking directory existence for ${dirPath}:`, error);
-        throw error; 
-    }
-}
-
-/**
  * Checks if a directory is a valid Git repository.
  */
 async function isGitRepository(dirPath: string): Promise<boolean> {


### PR DESCRIPTION
## Summary

Removes the dead `directoryExists()` helper from `gitbackup-cli`. It has **no call sites** anywhere in the package and is not exported — `packages/gitbackup-cli/src/main.ts` is a pure executable entrypoint whose emitted `.d.ts` is `export {};`. It is leftover code from an earlier version of the clone/update flow, which now relies on `isGitRepository()` plus `simple-git`'s own "already exists" clone-error handling.

## Why this is safe (pure mechanical, zero logic change)

- **No live code path touched.** The only deleted symbol is `directoryExists` (function + its JSDoc). `grep` confirms zero references to it before removal.
- **Public surface byte-identical.** Emitted `dist/main.d.ts` is `export {};` both before and after — the package exposes no exports (it ships a `gitbackup` bin, not an API).
- **`fs` import still used** (`fs.mkdir` in two live functions), so no follow-on unused-import.
- All 6 live functions preserved: `getGitHubToken`, `fetchUserRepositories`, `isGitRepository`, `forceUpdateRepository`, `cloneOrUpdateRepository`, `main`.

## Gate results (local, this environment uses bun as the JS runtime)

| Gate | Command | Baseline (master) | This branch |
|------|---------|-------------------|-------------|
| Typecheck/build | `tsc` (`--noEmit` and emit) | ✅ pass (exit 0) | ✅ pass (exit 0) |
| Test | `vitest run` | ❌ exit 1 — *no test files exist in repo* | ❌ exit 1 (unchanged) |
| Lint | `eslint` | ❌ exit 2 — *no `eslint.config.js`; ESLint 9 cannot run* | ❌ exit 2 (unchanged) |
| Format | `prettier --check` | ❌ exit 1 — `main.ts` + `vitest.config.ts` already unformatted | ❌ exit 1 (unchanged) |

The only independently-green gate (`tsc`) stays green. The red gates are **pre-existing repo conditions unrelated to this change** (missing tests, missing ESLint flat-config, pre-existing prettier drift) and were deliberately left untouched to keep this PR a single mechanical dead-code deletion. The diff is `1 file changed, 19 deletions(-)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)