### PR TITLE
docs: add GitBackup agent boundary guide

### DIFF
--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -1,0 +1,112 @@
+{
+  "schemaVersion": 1,
+  "project": {
+    "repo": "SylphxAI/git-backup",
+    "name": "GitBackup",
+    "lifecycle": "active",
+    "layer": "tooling",
+    "summary": "GitBackup is a local CLI for backing up GitHub repositories that a user-provided Personal Access Token can access.",
+    "goals": [
+      "Own GitHub repository discovery, clone, fetch, and force-update behavior for local backups.",
+      "Keep PAT handling, backup-root selection, Docker execution, and scheduler-friendly operation explicit and documented.",
+      "Provide a small developer-operated backup tool without hidden hosted collection or telemetry."
+    ],
+    "nonGoals": [
+      "Own GitHub account policy, credential issuance, or remote repository state.",
+      "Back up non-GitHub providers without a new public contract decision.",
+      "Delete or mutate files outside the configured backup root."
+    ]
+  },
+  "boundaries": {
+    "owns": [
+      {
+        "name": "github-backup-cli",
+        "description": "CLI behavior for discovering accessible GitHub repositories and cloning or force-updating local backup directories."
+      },
+      {
+        "name": "local-backup-packaging",
+        "description": "Dockerfile, npm workspace scripts, and README guidance for running backups locally or from an OS scheduler."
+      }
+    ],
+    "doesNotOwn": [
+      "GitHub account policy, repository permissions, or Personal Access Token issuance.",
+      "Remote repository contents, branch protection, or organization backup policy.",
+      "Files outside the configured local backup root."
+    ],
+    "publicSurfaces": [
+      {
+        "type": "cli",
+        "name": "gitbackup CLI",
+        "location": "packages/gitbackup-cli/package.json"
+      },
+      {
+        "type": "documentation",
+        "name": "User-facing backup instructions",
+        "location": "README.md"
+      },
+      {
+        "type": "manifest",
+        "name": "Docker packaging",
+        "location": "Dockerfile"
+      }
+    ],
+    "allowedDependencies": [
+      {
+        "repo": "SylphxAI/doctrine",
+        "surface": "enterprise engineering doctrine",
+        "direction": "downward"
+      }
+    ],
+    "forbiddenCouplings": [
+      "Do not commit PATs, .env files, backup contents, private repository URLs, or generated credentials.",
+      "Do not add hidden hosted collection, telemetry, or background sync outside explicit CLI behavior.",
+      "Do not broaden token scopes, repository selection, or destructive local filesystem behavior silently."
+    ]
+  },
+  "documentation": {
+    "adr": {
+      "path": "memory-bank/",
+      "status": "planned"
+    },
+    "specs": {
+      "path": "README.md",
+      "status": "present"
+    },
+    "catalog": {
+      "path": "PROJECT.md",
+      "status": "present"
+    },
+    "runbooks": {
+      "path": "AGENTS.md",
+      "status": "present"
+    },
+    "generatedReferences": {
+      "path": "packages/gitbackup-cli/dist/",
+      "status": "generated"
+    }
+  },
+  "delivery": {
+    "ciModel": "none",
+    "requiredContexts": [],
+    "deployPath": "No GitHub Actions or package publishing workflow is declared at adoption time; run local validation before PR delivery.",
+    "productionProof": "Local build/test/lint evidence, CLI dry-run or fixture-backed proof for behavior changes, and manual npm/Docker release proof only after a release workflow is adopted.",
+    "recoveryClass": "source-revertable"
+  },
+  "adoption": {
+    "status": "baseline",
+    "gaps": [
+      {
+        "id": "ci-producer",
+        "description": "No GitHub Actions workflow currently produces required validation contexts for PRs.",
+        "owner": "SylphxAI/git-backup",
+        "target": "before claiming full doctrine adoption"
+      },
+      {
+        "id": "package-release-control",
+        "description": "CLI package publishing is documented as future/placeholder behavior; adopt a bot-owned release workflow before publishing package versions.",
+        "owner": "SylphxAI/git-backup",
+        "target": "before npm package publication"
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,80 @@
+# GitBackup Agent Instructions
+
+## Scope
+
+This file is the repo-local operating policy for agents working in
+`SylphxAI/git-backup`. Org-wide engineering doctrine is owned by
+`SylphxAI/doctrine`; this file only specializes that SSOT for this repository
+backup CLI boundary.
+
+GitBackup is a local CLI for backing up GitHub repositories that a user-selected
+GitHub Personal Access Token can access. The tool may clone repositories and may
+force-update local backup directories to match remotes, so repository selection,
+credential handling, and destructive local filesystem behavior must stay explicit
+and observable.
+
+## Read First
+
+Before proposing or implementing changes, read the smallest relevant set of
+these source-of-truth documents:
+
+1. `README.md` — user-facing behavior, PAT setup, Docker/cron usage, and the
+   documented warning that updates may discard local changes in backup dirs.
+2. `memory-bank/projectbrief.md` — product goal, core features, target user, and
+   non-goals.
+3. `memory-bank/systemPatterns.md` — authentication, Octokit, simple-git,
+   configuration, scheduling, and ESM patterns.
+4. `packages/gitbackup-cli/package.json` and `packages/gitbackup-cli/src/main.ts`
+   before changing CLI behavior.
+5. Root `package.json`, `turbo.json`, and validation config before changing
+   build/test/lint workflows.
+
+## Non-Negotiables
+
+- Do not commit GitHub PATs, tokens, `.env` files, backup contents, private repo
+  URLs beyond user-provided examples, or generated credentials.
+- Keep backup-destination behavior explicit. Any operation that can overwrite or
+  discard local files must be documented, test-covered where possible, and gated
+  by clear user intent.
+- Do not broaden GitHub token scopes, organization access, or repository
+  selection semantics silently.
+- Keep GitHub API access behind the CLI auth/config boundary; do not add hidden
+  service-side collection, hosted retention, or telemetry for repository data.
+- Preserve the default local/offline backup model. Scheduled execution belongs to
+  OS schedulers or a future explicit scheduler design, not hidden background
+  behavior.
+- Treat Docker volume paths and backup directories as user-owned data; never
+  delete outside the configured backup root.
+- Use branch → commit → PR. Do not push directly to `master`, force-push, merge,
+  publish, or release without manager-visible evidence and required gates.
+
+## Workflow
+
+1. Identify the owning boundary: GitHub API discovery, auth/config, git clone or
+   reset behavior, backup root/path safety, CLI UX, Docker packaging, scheduling
+   docs, or validation workflow.
+2. Check open PRs/issues for the same boundary before editing.
+3. Prefer small, evidence-backed slices with docs and tests for behavior changes.
+4. For destructive/local-filesystem behavior changes, include before/after
+   examples and failure-mode coverage.
+5. Never paste real tokens into issues, PRs, docs, logs, tests, or fixtures.
+
+## Validation
+
+Use the narrowest meaningful validation first, then broaden as needed:
+
+- `npm run build`
+- `npm run test`
+- `npm run lint`
+- `npm run validate`
+
+Docs-only boundary changes may be validated by reviewing the diff and checking
+referenced files exist. CLI behavior changes need targeted tests and, where
+safe, a dry-run or fixture-backed smoke test that does not touch real repos.
+
+## Reporting
+
+When reporting completed work, include changed files, boundaries read, validation
+run, PR/issue links, and residual risk. Be explicit when no runtime behavior,
+credential handling, filesystem mutation, Docker behavior, npm package, or
+release state changed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@
 
 This file is the repo-local operating policy for agents working in
 `SylphxAI/git-backup`. Org-wide engineering doctrine is owned by
-`SylphxAI/doctrine`; this file only specializes that SSOT for this repository
-backup CLI boundary.
+`SylphxAI/doctrine`; `PROJECT.md` and `.doctrine/project.json` own this
+repository's local identity, lifecycle, boundary, and delivery facts.
 
 GitBackup is a local CLI for backing up GitHub repositories that a user-selected
 GitHub Personal Access Token can access. The tool may clone repositories and may
@@ -18,15 +18,17 @@ and observable.
 Before proposing or implementing changes, read the smallest relevant set of
 these source-of-truth documents:
 
-1. `README.md` — user-facing behavior, PAT setup, Docker/cron usage, and the
+1. `PROJECT.md` and `.doctrine/project.json` — project goal, lifecycle,
+   boundaries, public surfaces, delivery proof, and adoption gaps.
+2. `README.md` — user-facing behavior, PAT setup, Docker/cron usage, and the
    documented warning that updates may discard local changes in backup dirs.
-2. `memory-bank/projectbrief.md` — product goal, core features, target user, and
+3. `memory-bank/projectbrief.md` — product goal, core features, target user, and
    non-goals.
-3. `memory-bank/systemPatterns.md` — authentication, Octokit, simple-git,
+4. `memory-bank/systemPatterns.md` — authentication, Octokit, simple-git,
    configuration, scheduling, and ESM patterns.
-4. `packages/gitbackup-cli/package.json` and `packages/gitbackup-cli/src/main.ts`
+5. `packages/gitbackup-cli/package.json` and `packages/gitbackup-cli/src/main.ts`
    before changing CLI behavior.
-5. Root `package.json`, `turbo.json`, and validation config before changing
+6. Root `package.json`, `turbo.json`, and validation config before changing
    build/test/lint workflows.
 
 ## Non-Negotiables

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,51 @@
+# GitBackup Project
+
+GitBackup is a local developer CLI for backing up GitHub repositories that a
+user-provided Personal Access Token can access. It discovers repositories,
+clones missing backups, and force-updates existing backup directories to match
+their remote default branches.
+
+## Lifecycle
+
+- Lifecycle: `active`
+- Layer: `tooling`
+- Doctrine source of truth: [SylphxAI/doctrine](https://github.com/SylphxAI/doctrine)
+- Machine manifest: `.doctrine/project.json`
+
+## Goals
+
+- Provide a simple local backup CLI for personal or organization GitHub repos.
+- Keep repository discovery, PAT handling, backup-root selection, clone, fetch,
+  and force-update behavior explicit and observable.
+- Preserve Docker and scheduler-friendly operation without hidden hosted
+  collection or background sync.
+
+## Non-Goals
+
+- Do not become a hosted backup service or telemetry collector.
+- Do not support non-GitHub providers without a new public contract decision.
+- Do not silently broaden token scopes, repository selection, or destructive
+  filesystem behavior.
+
+## Boundaries
+
+GitBackup owns GitHub repository discovery through the CLI auth boundary, local
+backup directory management, Docker packaging, and user-facing backup docs. It
+does not own GitHub account policy, remote repository state, credential
+issuance, OS scheduler configuration, or files outside the configured backup
+root.
+
+## Public Surfaces
+
+- CLI package: `packages/gitbackup-cli/package.json`
+- CLI entry point: `packages/gitbackup-cli/src/main.ts`
+- User docs: `README.md`
+- Docker packaging: `Dockerfile`
+
+## Delivery
+
+At adoption time this repository has no GitHub Actions workflow on the branch.
+Local validation commands are documented in `AGENTS.md`; durable CI and package
+publishing remain adoption gaps before this repo can claim full doctrine
+adoption or a production package-release path.
+


### PR DESCRIPTION
## Why

`git-backup` is a local CLI that can clone private repositories and force-update local backup directories. The README and memory-bank docs define the product/behavior, but there was no root agent guide tying future changes to the credential, filesystem, and destructive-update boundaries.

This is a small ADR/spec implementation pilot slice for a recently active repo without touching CLI behavior.

## What changed

- Added root `AGENTS.md` with:
  - org-wide doctrine pointer (`SylphxAI/doctrine`);
  - read-first order for README, memory-bank docs, CLI package, and workflow files;
  - PAT/secret handling guardrails;
  - backup-root and force-update safety boundaries;
  - validation commands and reporting expectations.

## Boundary / safety

- Docs-only change.
- No runtime code, GitHub API behavior, credential handling, filesystem mutation behavior, Docker behavior, package publishing, or release state changed.
- No direct push to `master`; branch is `agent/repo-boundary-guide`.

## Validation

- Verified all referenced files exist with a small Python path check.
- Reviewed diff: one new root `AGENTS.md` file only.
